### PR TITLE
feat: Add ELF linker implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+a.out

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 bench:
 	@cargo +nightly bench
 
+build-obj:
+	@cd src/parser/fixtures && gcc -c main.c -o main.o && gcc -c sub.c -o sub.o
+
 test:
 	@cargo nextest run
 
-build:
+build: build-obj
 	@cargo run -- a.out src/parser/fixtures/main.o src/parser/fixtures/sub.o
 
 run: build

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,12 @@ bench:
 
 test:
 	@cargo nextest run
+
+build:
+	@cargo run -- a.out src/parser/fixtures/main.o src/parser/fixtures/sub.o
+
+run: build
+	@./a.out; echo $$?
+
+dump: build
+	@readelf -l -s -S a.out; objdump -d a.out

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -5,10 +5,18 @@ pub mod section;
 pub mod segument;
 pub mod symbol;
 
+/// Represents an ELF (Executable and Linkable Format) file.
+///
+/// This structure contains the parsed components of an ELF file, including its header,
+/// section headers, symbols, and relocations.
 #[derive(Debug)]
-pub struct Elf {
+pub struct ELF {
+    /// The ELF file header, containing metadata about the file.
     pub header: header::Header,
+    /// A list of section headers, describing the sections in the ELF file.
     pub section_headers: Vec<section::Header>,
+    /// A list of symbols defined in the ELF file.
     pub symbols: Vec<symbol::Symbol>,
+    /// A list of relocation entries with addends.
     pub relocations: Vec<relocation::RelocationAddend>,
 }

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -1,11 +1,23 @@
 pub mod header;
+pub mod program_header;
 pub mod relocation;
 pub mod section;
+pub mod segument;
 pub mod symbol;
 
+#[derive(Debug)]
 pub struct Elf<'a> {
     pub header: header::Header,
     pub section_headers: Vec<section::Header<'a>>,
     pub symbols: Vec<symbol::Symbol>,
     pub relocations: Vec<relocation::RelocationAddend>,
+}
+
+#[derive(Debug)]
+pub struct LinkedElf<'a> {
+    pub header: header::Header,
+    pub program_headers: Vec<program_header::ProgramHeader>,
+    pub sections: Vec<section::Header<'a>>,
+    // pub symbols: Vec<symbol::Symbol>,
+    // pub relocations: Vec<relocation::RelocationAddend>,
 }

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -6,18 +6,9 @@ pub mod segument;
 pub mod symbol;
 
 #[derive(Debug)]
-pub struct Elf<'a> {
+pub struct Elf {
     pub header: header::Header,
-    pub section_headers: Vec<section::Header<'a>>,
+    pub section_headers: Vec<section::Header>,
     pub symbols: Vec<symbol::Symbol>,
     pub relocations: Vec<relocation::RelocationAddend>,
-}
-
-#[derive(Debug)]
-pub struct LinkedElf<'a> {
-    pub header: header::Header,
-    pub program_headers: Vec<program_header::ProgramHeader>,
-    pub sections: Vec<section::Header<'a>>,
-    // pub symbols: Vec<symbol::Symbol>,
-    // pub relocations: Vec<relocation::RelocationAddend>,
 }

--- a/src/elf/header.rs
+++ b/src/elf/header.rs
@@ -1,4 +1,5 @@
-#[derive(Default, Debug, PartialEq, Eq)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(u8)]
 pub enum Class {
     #[default]
     None = 0,
@@ -7,7 +8,8 @@ pub enum Class {
     Num = 3,
 }
 
-#[derive(Default, Debug, PartialEq, Eq)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(u8)]
 pub enum Data {
     #[default]
     None = 0, // unknown
@@ -16,7 +18,8 @@ pub enum Data {
     Num = 3,
 }
 
-#[derive(Default, Debug, PartialEq, Eq)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(u8)]
 pub enum IdentVersion {
     #[default]
     None = 0,
@@ -24,7 +27,8 @@ pub enum IdentVersion {
     Num = 2,
 }
 
-#[derive(Default, Debug, PartialEq, Eq)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(u8)]
 pub enum OSABI {
     #[default]
     SystemV = 0, // or none
@@ -52,7 +56,8 @@ pub struct Ident {
     pub abi_version: u8,
 }
 
-#[derive(Default, Debug, PartialEq, Eq)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(u16)]
 pub enum Type {
     #[default]
     None = 0, // No file type
@@ -67,7 +72,8 @@ pub enum Type {
     Hiproc = 0xffff, // Processor-specific range end
 }
 
-#[derive(Default, Debug, PartialEq, Eq)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(u16)]
 pub enum Machine {
     #[default]
     None = 0,
@@ -78,7 +84,8 @@ pub enum Machine {
     Num = 253,
 }
 
-#[derive(Default, Debug, PartialEq, Eq)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(u32)]
 pub enum Version {
     #[default]
     None = 0,

--- a/src/elf/header.rs
+++ b/src/elf/header.rs
@@ -93,20 +93,38 @@ pub enum Version {
     Num = 2,
 }
 
+/// Represents the ELF (Executable and Linkable Format) file header.
+///
+/// The ELF header contains metadata about the ELF file, such as its type, architecture,
+/// entry point, and offsets to other important structures like the program and section headers.
 #[derive(Default, Debug, PartialEq, Eq)]
 pub struct Header {
-    pub ident: Ident,     // Magic number and other info
-    pub r#type: Type,     // Object file type
-    pub machine: Machine, // Architecture
-    pub version: Version, // Object file version
-    pub entry: u64,       // Entry point virtual address
-    pub phoff: u64,       // Program header table file offset
-    pub shoff: u64,       // Section header table file offset
-    pub flags: u32,       // Processor-specific flags
-    pub ehsize: u16,      // ELF header size in bytes
-    pub phentsize: u16,   // Program header table entry size
-    pub phnum: u16,       // Program header table entry count
-    pub shentsize: u16,   // Section header table entry size
-    pub shnum: u16,       // Section header table entry count
-    pub shstrndx: u16,    // Section header string table index
+    /// Identification information, including the magic number and file class.
+    pub ident: Ident,
+    /// The type of the ELF file (e.g., relocatable, executable, shared object).
+    pub r#type: Type,
+    /// The target architecture for the ELF file (e.g., x86, ARM).
+    pub machine: Machine,
+    /// The version of the ELF file format.
+    pub version: Version,
+    /// The virtual address of the entry point for the program.
+    pub entry: u64,
+    /// The file offset to the program header table.
+    pub phoff: u64,
+    /// The file offset to the section header table.
+    pub shoff: u64,
+    /// Processor-specific flags.
+    pub flags: u32,
+    /// The size of the ELF header in bytes.
+    pub ehsize: u16,
+    /// The size of each entry in the program header table.
+    pub phentsize: u16,
+    /// The number of entries in the program header table.
+    pub phnum: u16,
+    /// The size of each entry in the section header table.
+    pub shentsize: u16,
+    /// The number of entries in the section header table.
+    pub shnum: u16,
+    /// The index of the section header string table.
+    pub shstrndx: u16,
 }

--- a/src/elf/header.rs
+++ b/src/elf/header.rs
@@ -56,20 +56,35 @@ pub struct Ident {
     pub abi_version: u8,
 }
 
+/// Represents the type of an ELF file.
+///
+/// This enum defines various types of ELF files, such as relocatable files,
+/// executable files, shared object files, and core files. It also includes
+/// ranges for OS-specific and processor-specific types.
 #[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
 #[repr(u16)]
 pub enum Type {
+    /// No file type.
     #[default]
-    None = 0, // No file type
-    Rel = 1,         // Relocatable file
-    Exec = 2,        // Executable file
-    Dyn = 3,         // Shared object file
-    Core = 4,        // Core file
-    Num = 5,         // Number of defined types
-    Loos = 0xfe00,   // OS-specific range start
-    Hios = 0xfeff,   // OS-specific range end
-    Loproc = 0xff00, // Processor-specific range start
-    Hiproc = 0xffff, // Processor-specific range end
+    None = 0,
+    /// Relocatable file.
+    Rel = 1,
+    /// Executable file.
+    Exec = 2,
+    /// Shared object file.
+    Dyn = 3,
+    /// Core file.
+    Core = 4,
+    /// Number of defined types.
+    Num = 5,
+    /// OS-specific range start.
+    Loos = 0xfe00,
+    /// OS-specific range end.
+    Hios = 0xfeff,
+    /// Processor-specific range start.
+    Loproc = 0xff00,
+    /// Processor-specific range end.
+    Hiproc = 0xffff,
 }
 
 #[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]

--- a/src/elf/program_header.rs
+++ b/src/elf/program_header.rs
@@ -1,0 +1,13 @@
+use crate::elf::segument;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ProgramHeader {
+    pub r#type: segument::Type,     // Segment type
+    pub flags: Vec<segument::Flag>, // Segment flags
+    pub offset: u64,                // Segment file offset
+    pub vaddr: u64,                 // Segment virtual address
+    pub paddr: u64,                 // Segment physical address
+    pub filesz: u64,                // Segment size in file
+    pub memsz: u64,                 // Segment size in memory
+    pub align: u64,                 // Segment alignment
+}

--- a/src/elf/relocation.rs
+++ b/src/elf/relocation.rs
@@ -10,9 +10,18 @@ pub struct Info {
     pub symbol_index: u32,
 }
 
+/// Represents an ELF relocation entry with an explicit addend (Rela).
+///
+/// This struct corresponds to the Elf64_Rela structure in the ELF specification.
+/// It contains the information needed to relocate a symbol in the object file.
 #[derive(Debug, PartialEq, Eq)]
 pub struct RelocationAddend {
-    pub offset: u64, // Address
-    pub info: Info,  // Relocation type and symbol index
-    pub addend: i64, // Addend
+    /// The location to be modified, expressed as an offset from the beginning
+    /// of the section or file where the relocation applies.
+    pub offset: u64,
+    /// Contains both the symbol index and relocation type.
+    /// The specific encoding depends on the target architecture.
+    pub info: Info,
+    /// The constant addend used to compute the value to be stored into the relocatable field.
+    pub addend: i64,
 }

--- a/src/elf/section.rs
+++ b/src/elf/section.rs
@@ -1,4 +1,5 @@
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(u32)]
 pub enum SectionType {
     Null = 0,                   // Section header table entry unused
     ProgBits = 1,               // Program data
@@ -40,7 +41,7 @@ pub enum SectionFlag {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct Header<'a> {
+pub struct Header {
     pub name_idx: u32,           // Section name (string tbl index)
     pub name: String,            // Section name
     pub r#type: SectionType,     // Section type
@@ -52,5 +53,5 @@ pub struct Header<'a> {
     pub info: u32,               // Additional section information
     pub addralign: u64,          // Section alignment
     pub entsize: u64,            // Entry size if section holds table
-    pub data: &'a [u8],
+    pub data: Vec<u8>,
 }

--- a/src/elf/section.rs
+++ b/src/elf/section.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum SectionType {
     Null = 0,                   // Section header table entry unused
     ProgBits = 1,               // Program data

--- a/src/elf/section.rs
+++ b/src/elf/section.rs
@@ -110,5 +110,5 @@ pub struct Header {
     /// Size of each entry in the section, if it holds a table.
     pub entsize: u64,
     /// Raw data contained in the section.
-    pub data: Vec<u8>,
+    pub section_raw_data: Vec<u8>,
 }

--- a/src/elf/section.rs
+++ b/src/elf/section.rs
@@ -40,18 +40,75 @@ pub enum SectionFlag {
     Compressed = 1 << 11, // Section with compressed data
 }
 
+/// Represents the header of an ELF section.
+///
+/// This structure contains metadata about a section in an ELF file, including its name,
+/// type, flags, memory address, file offset, size, and other attributes.
+///
+/// # Example: Relationship Between Section Header and .text Section
+///
+/// ```text
+/// ELF File Layout:
+/// +-------------------+
+/// | ELF Header        |
+/// +-------------------+
+/// | Section Header 1  |--> Describes .text section
+/// +-------------------+
+/// | Section Header 2  |
+/// +-------------------+
+/// | Section Header 3  |
+/// +-------------------+
+/// | ...               |
+/// +-------------------+
+/// | .text Section     |--> Contains executable code
+/// +-------------------+
+/// | ...               |
+/// +-------------------+
+///
+/// Section Header 1 (for .text):
+/// +-------------------+
+/// | Name Index: 1     |--> Points to ".text" in the string table
+/// +-------------------+
+/// | Type: PROGBITS    |--> Indicates this section contains program code
+/// +-------------------+
+/// | Flags: EXEC       |--> Executable section
+/// +-------------------+
+/// | Address: 0x1000   |--> Virtual memory address during execution
+/// +-------------------+
+/// | Offset: 0x200     |--> Offset in the ELF file where .text starts
+/// +-------------------+
+/// | Size: 0x300       |--> Size of the .text section in bytes
+/// +-------------------+
+///
+/// .text Section:
+/// +-------------------+
+/// | Machine Code      |--> Raw binary instructions for execution
+/// +-------------------+
+/// ```
 #[derive(Debug, PartialEq, Eq)]
 pub struct Header {
-    pub name_idx: u32,           // Section name (string tbl index)
-    pub name: String,            // Section name
-    pub r#type: SectionType,     // Section type
-    pub flags: Vec<SectionFlag>, // Section flags
-    pub addr: u64,               // Section virtual addr at execution
-    pub offset: u64,             // Section file offset
-    pub size: u64,               // Section size in bytes
-    pub link: u32,               // Link to another section
-    pub info: u32,               // Additional section information
-    pub addralign: u64,          // Section alignment
-    pub entsize: u64,            // Entry size if section holds table
+    /// Index of the section name in the string table.
+    pub name_idx: u32,
+    /// Name of the section.
+    pub name: String,
+    /// Type of the section.
+    pub r#type: SectionType,
+    /// Flags associated with the section.
+    pub flags: Vec<SectionFlag>,
+    /// Virtual memory address of the section during execution.
+    pub addr: u64,
+    /// Offset of the section in the ELF file.
+    pub offset: u64,
+    /// Size of the section in bytes.
+    pub size: u64,
+    /// Index of a related section, if applicable.
+    pub link: u32,
+    /// Additional information about the section.
+    pub info: u32,
+    /// Alignment of the section in memory.
+    pub addralign: u64,
+    /// Size of each entry in the section, if it holds a table.
+    pub entsize: u64,
+    /// Raw data contained in the section.
     pub data: Vec<u8>,
 }

--- a/src/elf/segument.rs
+++ b/src/elf/segument.rs
@@ -1,0 +1,56 @@
+#[derive(Debug, PartialEq, Eq)]
+pub enum Type {
+    Null = 0,                // Program header table entry unused
+    Load = 1,                // Loadable program segment
+    Dynamic = 2,             // Dynamic linking information
+    Interp = 3,              // Program interpreter
+    Note = 4,                // Auxiliary information
+    ShLib = 5,               // Reserved
+    Phdr = 6,                // Entry for header table itself
+    Tls = 7,                 // Thread-local storage segment
+    Num = 8,                 // Number of defined types
+    LoOs = 0x60000000,       // Start of OS-specific
+    GnuEhFrame = 0x6474e550, // GCC .eh_frame_hdr segment
+    GnuStack = 0x6474e551,   // Indicates stack executability
+    GnuRelro = 0x6474e552,   // Read-only after relocation
+    SunwBss = 0x6ffffffa,    // Sun Specific segment
+    SunwStack = 0x6ffffffb,  // Stack segment
+    HiOs = 0x6fffffff,       // End of OS-specific
+    LoProc = 0x70000000,     // Start of processor-specific
+    HiProc = 0x7fffffff,     // End of processor-specific
+}
+
+#[repr(u32)]
+#[derive(Debug, PartialEq, Eq)]
+pub enum Flag {
+    Executable = 0x1,      // Segment is executable
+    Writable = 0x2,        // Segment is writable
+    Readable = 0x4,        // Segment is readable
+    MaskOS = 0x0ff00000,   // OS-specific
+    MaskProc = 0xf0000000, // Processor-specific
+}
+
+// TODO
+// .text
+// .rodata
+// .hash
+// .dynsym
+// .dynstr
+// .plt
+// .rel.got
+#[derive(Debug, PartialEq, Eq)]
+pub struct TextSegument {}
+
+// TODO
+// .data
+// .dynamic
+// .got
+// .bss
+#[derive(Debug, PartialEq, Eq)]
+pub struct DataSegument {}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Segument {
+    Text(TextSegument),
+    Data(DataSegument),
+}

--- a/src/elf/segument.rs
+++ b/src/elf/segument.rs
@@ -1,4 +1,5 @@
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(u32)]
 pub enum Type {
     Null = 0,                // Program header table entry unused
     Load = 1,                // Loadable program segment
@@ -20,8 +21,8 @@ pub enum Type {
     HiProc = 0x7fffffff,     // End of processor-specific
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[repr(u32)]
-#[derive(Debug, PartialEq, Eq)]
 pub enum Flag {
     Executable = 0x1,      // Segment is executable
     Writable = 0x2,        // Segment is writable

--- a/src/elf/symbol.rs
+++ b/src/elf/symbol.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Type {
     NoType = 0,  // Symbol type is unspecified
     Object = 1,  // Symbol is a data object
@@ -14,7 +14,7 @@ pub enum Type {
     Hiproc = 15, // End of processor-specific
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Binding {
     Local = 0,   // Local symbol
     Global = 1,  // Global symbol

--- a/src/elf/symbol.rs
+++ b/src/elf/symbol.rs
@@ -41,6 +41,21 @@ pub enum Visibility {
     Protected = 3, // Not preemptible, not exported
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(u16)]
+pub enum SymbolIndex {
+    Undefined = 0,
+    Abs = 0xfff1,
+    Common = 0xfff2,
+    // TODO
+}
+
+impl PartialEq<u16> for SymbolIndex {
+    fn eq(&self, other: &u16) -> bool {
+        (*self as u16) == *other
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct Symbol {
     pub name: String,      // Symbol name

--- a/src/elf/symbol.rs
+++ b/src/elf/symbol.rs
@@ -1,4 +1,5 @@
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(u8)]
 pub enum Type {
     NoType = 0,  // Symbol type is unspecified
     Object = 1,  // Symbol is a data object
@@ -15,6 +16,7 @@ pub enum Type {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(u8)]
 pub enum Binding {
     Local = 0,   // Local symbol
     Global = 1,  // Global symbol

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
-pub mod elf;
 mod macros;
+
+pub mod elf;
 pub mod parser;
+pub mod linker;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 mod macros;
 
 pub mod elf;
-pub mod parser;
 pub mod linker;
+pub mod parser;

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -1,0 +1,1457 @@
+#![allow(clippy::too_many_arguments)]
+
+use std::collections::HashMap;
+use std::fs;
+use std::io;
+use std::io::Seek;
+use std::io::SeekFrom;
+use std::io::Write;
+use std::path::Path;
+
+use crate::elf::{header, program_header, relocation, section, segument, symbol};
+use crate::parser;
+
+/// 出力セクション情報
+#[derive(Debug, Clone)]
+pub struct OutputSection {
+    /// セクション名
+    pub name: String,
+    /// セクションタイプ
+    pub r#type: section::SectionType,
+    /// セクション属性フラグ
+    pub flags: Vec<section::SectionFlag>,
+    /// セクション仮想アドレス
+    pub addr: u64,
+    /// ファイル内オフセット
+    pub offset: u64,
+    /// セクションサイズ
+    pub size: u64,
+    /// セクションデータ
+    pub data: Vec<u8>,
+    /// アラインメント制約
+    pub align: u64,
+}
+
+/// シンボル情報を保持する構造体
+#[derive(Debug, Clone)]
+pub struct ResolvedSymbol {
+    /// シンボル名
+    pub name: String,
+    /// シンボルの最終的な値（アドレスなど）
+    pub value: u64,
+    /// シンボルのサイズ
+    pub size: u64,
+    /// シンボルの種類
+    pub r#type: symbol::Type,
+    /// シンボルのバインディング（グローバル、ローカルなど）
+    pub binding: symbol::Binding,
+    /// シンボルが所属するセクションのインデックス
+    pub section_index: u16,
+    /// シンボルが定義されているオブジェクトファイルのインデックス
+    pub object_index: usize,
+    /// シンボルが定義済みかどうか
+    pub is_defined: bool,
+}
+
+impl ResolvedSymbol {
+    /// シンボルの強さを比較する（Local > Global > Weak）
+    pub fn is_stronger_than(&self, other: &Self) -> bool {
+        match (self.binding, other.binding) {
+            // Local が最も強い
+            (symbol::Binding::Local, _) => true,
+            // Weak が最も弱い
+            (_, symbol::Binding::Weak) => true,
+            // Global は Local より弱いが Weak より強い
+            (symbol::Binding::Global, symbol::Binding::Global) => false, // 同じ強さ
+            (symbol::Binding::Global, symbol::Binding::Local) => false,  // 自分が弱い
+            (symbol::Binding::Weak, _) => false,                         // 自分が弱い
+            _ => false,                                                  // その他のケース
+        }
+    }
+
+    /// 現在のシンボルが未定義で、引数のシンボルが定義済みかどうかチェック
+    pub fn is_undefined_and_other_defined(&self, other: &Self) -> bool {
+        !self.is_defined && other.is_defined
+    }
+}
+
+/// オブジェクトファイル情報を管理する構造体
+/// ライフタイムの問題を回避するため、ELFの主要情報をコピーして保持する
+#[derive(Debug)]
+struct ObjectFile {
+    // オリジナルのElfからデータを抽出して所有する形に変更
+    #[allow(dead_code)]
+    header: header::Header,
+    #[allow(dead_code)]
+    section_headers: Vec<OwnedSectionHeader>,
+    symbols: Vec<symbol::Symbol>,
+    #[allow(dead_code)]
+    relocations: Vec<relocation::RelocationAddend>,
+    #[allow(dead_code)]
+    raw_data: Vec<u8>, // 元のバイナリデータ
+}
+
+/// セクションヘッダーで所有権を持つバージョン
+#[derive(Debug)]
+#[allow(dead_code)]
+struct OwnedSectionHeader {
+    name: String,
+    r#type: section::SectionType,
+    flags: Vec<section::SectionFlag>,
+    addr: u64,
+    offset: u64,
+    size: u64,
+    link: u32,
+    info: u32,
+    addralign: u64,
+    entsize: u64,
+    data: Vec<u8>, // データをコピーして所有
+}
+
+impl From<section::Header<'_>> for OwnedSectionHeader {
+    fn from(header: section::Header<'_>) -> Self {
+        OwnedSectionHeader {
+            name: header.name,
+            r#type: header.r#type,
+            flags: header.flags,
+            addr: header.addr,
+            offset: header.offset,
+            size: header.size,
+            link: header.link,
+            info: header.info,
+            addralign: header.addralign,
+            entsize: header.entsize,
+            data: header.data.to_vec(), // データをコピー
+        }
+    }
+}
+
+/// リンカーの基本構造体
+#[derive(Debug, Default)]
+pub struct Linker {
+    objects: Vec<ObjectFile>,
+}
+
+impl Linker {
+    /// 新しいリンカーインスタンスを作成
+    pub fn new() -> Self {
+        Linker {
+            objects: Vec::new(),
+        }
+    }
+
+    /// オブジェクトファイルをリンカーに追加
+    pub fn add_object(mut self, path: &Path) -> io::Result<Self> {
+        // ファイルの内容を読み込む
+        let data = fs::read(path)?;
+
+        // ELFとしてパース
+        let elf = match parser::parse_elf(&data) {
+            Ok((_, elf)) => elf,
+            Err(e) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("ELFパースエラー: {:?}", e),
+                ));
+            }
+        };
+
+        // ELFデータを所有権のある形式に変換
+        let owned_section_headers = elf
+            .section_headers
+            .into_iter()
+            .map(OwnedSectionHeader::from)
+            .collect();
+
+        // オブジェクトファイル情報を追加
+        self.objects.push(ObjectFile {
+            header: elf.header,
+            section_headers: owned_section_headers,
+            symbols: elf.symbols,
+            relocations: elf.relocations,
+            raw_data: data,
+        });
+
+        Ok(self)
+    }
+
+    /// リンク処理全体を実行し、実行可能ファイルを出力する
+    pub fn link_to_file(&self, output_path: &Path) -> Result<(), String> {
+        // リンク処理を実行
+        let output_sections = self.link()?;
+
+        // 実行可能ファイルに書き出し
+        self.write_executable(output_path, &output_sections)
+    }
+
+    /// 実行可能ファイルを出力する
+    pub fn write_executable(
+        &self,
+        output_path: &Path,
+        output_sections: &[OutputSection],
+    ) -> Result<(), String> {
+        // ファイルを作成
+        let mut file = fs::File::create(output_path)
+            .map_err(|e| format!("出力ファイルの作成に失敗: {}", e))?;
+
+        // まずシンボル解決を行い、_startシンボルのアドレスを取得
+        let (mut resolved_symbols, _) = self.resolve_symbols();
+
+        // セクションレイアウトを行う（シンボルアドレスが更新される）
+        self.layout_sections(&mut resolved_symbols);
+
+        // _startシンボルのアドレスをエントリポイントに設定
+        let mut entry_point = 0x400000; // 修正: テキストセクションの開始アドレス
+        if let Some(start_symbol) = resolved_symbols.get("_start") {
+            println!("_startシンボルのアドレスを設定: 0x{:x}", start_symbol.value);
+            entry_point = start_symbol.value;
+        } else {
+            println!(
+                "警告: _startシンボルが見つかりません。テキストセクションの開始アドレス(0x401000)を使用します。"
+            );
+        }
+
+        // シンボル文字列テーブル(.strtab)を作成
+        let mut strtab_data: Vec<u8> = Vec::new();
+        let mut symbol_name_offsets: HashMap<String, usize> = HashMap::new();
+
+        // 文字列テーブルの先頭はNULL文字
+        strtab_data.push(0);
+
+        // シンボル名をテーブルに追加
+        for name in resolved_symbols.keys() {
+            if !name.is_empty() && !symbol_name_offsets.contains_key(name) {
+                let offset = strtab_data.len();
+                symbol_name_offsets.insert(name.clone(), offset);
+                strtab_data.extend_from_slice(name.as_bytes());
+                strtab_data.push(0); // NULL終端
+            }
+        }
+
+        // シンボルテーブル(.symtab)を作成
+        let mut symtab_data: Vec<u8> = Vec::new();
+
+        // NULL シンボルエントリ
+        self.write_symbol_entry(&mut symtab_data, 0, 0, 0, 0, 0, 0);
+
+        // 各シンボルのエントリを追加
+        for (name, symbol) in &resolved_symbols {
+            if symbol.is_defined {
+                let name_offset = *symbol_name_offsets.get(name).unwrap_or(&0);
+                let sym_binding = match symbol.binding {
+                    symbol::Binding::Local => 0,  // STB_LOCAL
+                    symbol::Binding::Global => 1, // STB_GLOBAL
+                    symbol::Binding::Weak => 2,   // STB_WEAK
+                    _ => 0,
+                };
+                let sym_type = match symbol.r#type {
+                    symbol::Type::NoType => 0,  // STT_NOTYPE
+                    symbol::Type::Object => 1,  // STT_OBJECT
+                    symbol::Type::Func => 2,    // STT_FUNC
+                    symbol::Type::Section => 3, // STT_SECTION
+                    symbol::Type::File => 4,    // STT_FILE
+                    _ => 0,
+                };
+                let st_info = (sym_binding << 4) | sym_type;
+
+                self.write_symbol_entry(
+                    &mut symtab_data,
+                    name_offset as u32,
+                    symbol.value,
+                    symbol.size,
+                    st_info,
+                    0, // st_other
+                    symbol.section_index,
+                );
+            }
+        }
+
+        // シンボル文字列テーブルセクションを作成
+        let strtab_section = OutputSection {
+            name: ".strtab".to_string(),
+            r#type: section::SectionType::StrTab,
+            flags: vec![],
+            addr: 0,
+            offset: align(0x3000, 8),
+            size: strtab_data.len() as u64,
+            data: strtab_data,
+            align: 1,
+        };
+
+        // シンボルテーブルセクションを作成
+        let symtab_section = OutputSection {
+            name: ".symtab".to_string(),
+            r#type: section::SectionType::SymTab,
+            flags: vec![],
+            addr: 0,
+            offset: align(strtab_section.offset + strtab_section.size, 8),
+            size: symtab_data.len() as u64,
+            data: symtab_data,
+            align: 8,
+        };
+
+        // セクション名文字列テーブル(.shstrtab)を作成
+        let mut shstrtab_data: Vec<u8> = Vec::new();
+        let mut section_name_offsets: HashMap<String, usize> = HashMap::new();
+
+        // セクション名文字列テーブルの先頭はNULL文字
+        shstrtab_data.push(0);
+
+        // セクション名をテーブルに追加
+        for section in output_sections {
+            let offset = shstrtab_data.len();
+            section_name_offsets.insert(section.name.clone(), offset);
+            shstrtab_data.extend_from_slice(section.name.as_bytes());
+            shstrtab_data.push(0); // NULL終端
+        }
+
+        // .strtabと.symtabも追加
+        let strtab_name_offset = shstrtab_data.len();
+        section_name_offsets.insert(".strtab".to_string(), strtab_name_offset);
+        shstrtab_data.extend_from_slice(".strtab".as_bytes());
+        shstrtab_data.push(0); // NULL終端
+
+        let symtab_name_offset = shstrtab_data.len();
+        section_name_offsets.insert(".symtab".to_string(), symtab_name_offset);
+        shstrtab_data.extend_from_slice(".symtab".as_bytes());
+        shstrtab_data.push(0); // NULL終端
+
+        // .shstrtab自身も追加
+        let shstrtab_offset = shstrtab_data.len();
+        section_name_offsets.insert(".shstrtab".to_string(), shstrtab_offset);
+        shstrtab_data.extend_from_slice(".shstrtab".as_bytes());
+        shstrtab_data.push(0); // NULL終端
+
+        // セクション名文字列テーブルセクションを作成
+        let shstrtab_section = OutputSection {
+            name: ".shstrtab".to_string(),
+            r#type: section::SectionType::StrTab,
+            flags: vec![],
+            addr: 0, // メモリにロードされない
+            offset: align(symtab_section.offset + symtab_section.size, 8), // セクションデータの配置オフセット
+            size: shstrtab_data.len() as u64,
+            data: shstrtab_data,
+            align: 1,
+        };
+
+        // ELFヘッダーを作成
+        let mut elf_header = self.create_elf_header(output_sections);
+        elf_header.entry = entry_point;
+
+        // セクションヘッダーテーブルの位置を計算
+        let sections_with_tables = [
+            output_sections,
+            &[
+                strtab_section.clone(),
+                symtab_section.clone(),
+                shstrtab_section.clone(),
+            ],
+        ]
+        .concat();
+
+        // セクションヘッダーテーブルの位置を設定
+        let section_data_end = sections_with_tables
+            .iter()
+            .map(|s| s.offset + align(s.size, 8))
+            .max()
+            .unwrap_or(0x3000);
+
+        let sh_offset = align(section_data_end, 8);
+        elf_header.shoff = sh_offset;
+        elf_header.shentsize = 64; // セクションヘッダーエントリのサイズ (64ビットELF)
+        elf_header.shnum = (sections_with_tables.len() + 1) as u16; // NULL セクションも含める
+
+        // .shstrtabのインデックスを正しく設定
+        let shstrtab_idx = sections_with_tables
+            .iter()
+            .position(|s| s.name == ".shstrtab")
+            .unwrap_or(0);
+        elf_header.shstrndx = (shstrtab_idx + 1) as u16; // NULLセクションもあるため+1
+
+        // プログラムヘッダーを作成
+        let program_headers = self.create_program_headers(output_sections);
+
+        // ELFヘッダーを書き込み
+        self.write_elf_header(&mut file, &elf_header)
+            .map_err(|e| format!("ELFヘッダーの書き込みに失敗: {}", e))?;
+
+        // プログラムヘッダーを書き込み
+        self.write_program_headers(&mut file, &program_headers)
+            .map_err(|e| format!("プログラムヘッダーの書き込みに失敗: {}", e))?;
+
+        // セクションデータを書き込み
+        self.write_sections(&mut file, &sections_with_tables)
+            .map_err(|e| format!("セクションの書き込みに失敗: {}", e))?;
+
+        // セクションヘッダーテーブルを書き込み
+        file.seek(SeekFrom::Start(sh_offset))
+            .map_err(|e| format!("ファイルシークに失敗: {}", e))?;
+
+        // NULLセクションヘッダー
+        self.write_section_header(&mut file, 0, "", 0, 0, 0, 0, 0, 0, 0, 0, 0)
+            .map_err(|e| format!("NULLセクションヘッダーの書き込みに失敗: {}", e))?;
+
+        // 各セクションのヘッダーを書き込み
+        for section in sections_with_tables.iter() {
+            let name_offset = *section_name_offsets.get(&section.name).unwrap_or(&0);
+            let sh_type = match section.r#type {
+                section::SectionType::Null => 0,
+                section::SectionType::ProgBits => 1,
+                section::SectionType::SymTab => 2,
+                section::SectionType::StrTab => 3,
+                section::SectionType::Rela => 4,
+                section::SectionType::Hash => 5,
+                section::SectionType::Dynamic => 6,
+                section::SectionType::Note => 7,
+                section::SectionType::NoBits => 8,
+                section::SectionType::Rel => 9,
+                section::SectionType::ShLib => 10,
+                section::SectionType::DynSym => 11,
+                section::SectionType::InitArray => 14,
+                section::SectionType::FiniArray => 15,
+                section::SectionType::PreInitArray => 16,
+                section::SectionType::Group => 17,
+                section::SectionType::SymTabShndx => 18,
+                _ => 0,
+            };
+
+            let mut sh_flags: u64 = 0;
+            for flag in &section.flags {
+                let bit = match flag {
+                    section::SectionFlag::Write => 0x1,
+                    section::SectionFlag::Alloc => 0x2,
+                    section::SectionFlag::ExecInstr => 0x4,
+                    _ => 0,
+                };
+                sh_flags |= bit;
+            }
+
+            // シンボルテーブルの特別な設定
+            let (sh_link, sh_info) = if section.name == ".symtab" {
+                // sh_link: 文字列テーブルのセクションインデックス
+                // sh_info: ローカルシンボルの数 + 1
+                let strtab_idx = sections_with_tables
+                    .iter()
+                    .position(|s| s.name == ".strtab")
+                    .unwrap_or(0)
+                    + 1;
+                (strtab_idx as u32, 1) // ここではすべてグローバルシンボルと仮定
+            } else {
+                (0, 0)
+            };
+
+            // セクションエントリサイズ（シンボルテーブルの場合は24）
+            let sh_entsize = if section.name == ".symtab" {
+                24 // 64ビットELFのシンボルエントリサイズ
+            } else {
+                0
+            };
+
+            self.write_section_header(
+                &mut file,
+                name_offset as u32, // セクション名の文字列テーブルでのオフセット
+                &section.name,      // デバッグ用
+                sh_type,            // セクションタイプ
+                sh_flags,           // セクションフラグ
+                section.addr,       // メモリアドレス
+                section.offset,     // ファイルオフセット
+                section.size,       // セクションサイズ
+                sh_link,            // リンク（シンボルテーブル用）
+                sh_info,            // 情報（追加情報）
+                section.align,      // アラインメント
+                sh_entsize,         // エントリサイズ
+            )
+            .map_err(|e| {
+                format!(
+                    "セクションヘッダーの書き込みに失敗: {} ({})",
+                    e, section.name
+                )
+            })?;
+        }
+
+        Ok(())
+    }
+
+    /// ELFヘッダーを生成
+    fn create_elf_header(&self, output_sections: &[OutputSection]) -> header::Header {
+        // デフォルトのヘッダー
+        let mut elf_header = header::Header {
+            ident: header::Ident {
+                class: header::Class::Bit64,
+                data: header::Data::Lsb, // Little Endian
+                version: header::IdentVersion::Current,
+                os_abi: header::OSABI::SystemV,
+                abi_version: 0,
+            },
+            r#type: header::Type::Exec,
+            machine: header::Machine::AArch64,
+            version: header::Version::Current,
+            entry: 0x400000, // エントリポイント（_startシンボルのアドレス）
+            phoff: 64,       // プログラムヘッダーのオフセット（ELF64ヘッダーのサイズ）
+            shoff: 0,        // セクションヘッダーのオフセット（現在は使用しない）
+            flags: 0,
+            ehsize: 64,    // ELF64ヘッダーのサイズ
+            phentsize: 56, // プログラムヘッダーエントリのサイズ
+            phnum: 0,      // プログラムヘッダー数（後で更新）
+            shentsize: 0,  // セクションヘッダーのサイズ（現在は使用しない）
+            shnum: 0,      // セクションヘッダー数（現在は使用しない）
+            shstrndx: 0,   // セクション名文字列テーブルのインデックス（現在は使用しない）
+        };
+
+        // プログラムヘッダーの情報を更新
+        let ph_count = self.count_program_headers(output_sections);
+        elf_header.phnum = ph_count as u16;
+
+        elf_header
+    }
+
+    /// プログラムヘッダー数をカウント
+    fn count_program_headers(&self, _output_sections: &[OutputSection]) -> usize {
+        // 現在はテキストセクションとデータセクションの2つ
+        2
+    }
+
+    /// プログラムヘッダーを生成
+    fn create_program_headers(
+        &self,
+        output_sections: &[OutputSection],
+    ) -> Vec<program_header::ProgramHeader> {
+        let mut program_headers = Vec::new();
+
+        // テキストセクション（実行可能セクション）
+        if let Some(text_section) = output_sections.iter().find(|s| s.name == ".text") {
+            let text_ph = program_header::ProgramHeader {
+                r#type: segument::Type::Load,
+                flags: vec![segument::Flag::Readable, segument::Flag::Executable],
+                offset: text_section.offset,
+                vaddr: text_section.addr,
+                paddr: text_section.addr,
+                filesz: text_section.size,
+                memsz: text_section.size,
+                align: text_section.align,
+            };
+            program_headers.push(text_ph);
+        }
+
+        // データセクション（読み書き可能セクション）
+        if let Some(data_section) = output_sections.iter().find(|s| s.name == ".data") {
+            let data_ph = program_header::ProgramHeader {
+                r#type: segument::Type::Load,
+                flags: vec![segument::Flag::Readable, segument::Flag::Writable],
+                offset: data_section.offset,
+                vaddr: data_section.addr, // 既に適切に計算されているはずなので、そのまま使用
+                paddr: data_section.addr,
+                filesz: data_section.size,
+                memsz: data_section.size,
+                align: data_section.align,
+            };
+            program_headers.push(data_ph);
+        }
+
+        program_headers
+    }
+
+    /// ELFヘッダーをファイルに書き込む
+    fn write_elf_header(&self, file: &mut fs::File, header: &header::Header) -> io::Result<()> {
+        // ELF マジックナンバー
+        file.write_all(&[0x7f, b'E', b'L', b'F'])?;
+
+        // ELFクラス（32/64ビット）
+        let class = match header.ident.class {
+            header::Class::None => 0,
+            header::Class::Bit32 => 1,
+            header::Class::Bit64 => 2,
+            header::Class::Num => 3,
+        };
+        file.write_all(&[class])?;
+
+        // エンディアン
+        let data = match header.ident.data {
+            header::Data::None => 0,
+            header::Data::Lsb => 1, // Little Endian
+            header::Data::Msb => 2, // Big Endian
+            header::Data::Num => 3,
+        };
+        file.write_all(&[data])?;
+
+        // バージョン
+        let version = match header.ident.version {
+            header::IdentVersion::None => 0,
+            header::IdentVersion::Current => 1,
+            header::IdentVersion::Num => 2,
+        };
+        file.write_all(&[version])?;
+
+        // OS ABI
+        let osabi = match header.ident.os_abi {
+            header::OSABI::SystemV => 0,
+            header::OSABI::HpUx => 1,
+            header::OSABI::NetBsd => 2,
+            header::OSABI::Gnu => 3,
+            header::OSABI::Solaris => 6,
+            header::OSABI::Aix => 7,
+            header::OSABI::Irix => 8,
+            header::OSABI::FreeBsd => 9,
+            header::OSABI::Tru64 => 10,
+            header::OSABI::Modesto => 11,
+            header::OSABI::OpenBsd => 12,
+            header::OSABI::ArmAeabi => 64,
+            header::OSABI::Arm => 97,
+            header::OSABI::Standalone => 255,
+        };
+        file.write_all(&[osabi])?;
+
+        // ABI バージョン
+        file.write_all(&[header.ident.abi_version])?;
+
+        // パディング
+        file.write_all(&[0; 7])?;
+
+        // タイプ
+        let elf_type = match header.r#type {
+            header::Type::None => 0,
+            header::Type::Rel => 1,
+            header::Type::Exec => 2,
+            header::Type::Dyn => 3,
+            header::Type::Core => 4,
+            header::Type::Num => 5,
+            header::Type::Loos
+            | header::Type::Hios
+            | header::Type::Loproc
+            | header::Type::Hiproc => {
+                // これらは範囲を表す値なので、通常は直接使用しない
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "不正なELFタイプです",
+                ));
+            }
+        };
+        file.write_all(&(elf_type as u16).to_le_bytes())?;
+
+        // マシン
+        let machine = match header.machine {
+            header::Machine::None => 0,
+            header::Machine::X86_64 => 62,
+            header::Machine::AArch64 => 183,
+            header::Machine::RiscV => 243,
+            header::Machine::Num => 253,
+        };
+        file.write_all(&(machine as u16).to_le_bytes())?;
+
+        // バージョン（拡張）
+        let version_ex = match header.version {
+            header::Version::None => 0,
+            header::Version::Current => 1,
+            header::Version::Num => 2,
+        };
+        file.write_all(&(version_ex as u32).to_le_bytes())?;
+
+        // エントリポイント
+        file.write_all(&header.entry.to_le_bytes())?;
+
+        // プログラムヘッダーオフセット
+        file.write_all(&header.phoff.to_le_bytes())?;
+
+        // セクションヘッダーオフセット
+        file.write_all(&header.shoff.to_le_bytes())?;
+
+        // フラグ
+        file.write_all(&header.flags.to_le_bytes())?;
+
+        // ELFヘッダーサイズ
+        file.write_all(&header.ehsize.to_le_bytes())?;
+
+        // プログラムヘッダーエントリサイズ
+        file.write_all(&header.phentsize.to_le_bytes())?;
+
+        // プログラムヘッダー数
+        file.write_all(&header.phnum.to_le_bytes())?;
+
+        // セクションヘッダーエントリサイズ
+        file.write_all(&header.shentsize.to_le_bytes())?;
+
+        // セクションヘッダー数
+        file.write_all(&header.shnum.to_le_bytes())?;
+
+        // セクション名文字列テーブルのインデックス
+        file.write_all(&header.shstrndx.to_le_bytes())?;
+
+        Ok(())
+    }
+
+    /// プログラムヘッダーをファイルに書き込む
+    fn write_program_headers(
+        &self,
+        file: &mut fs::File,
+        headers: &[program_header::ProgramHeader],
+    ) -> io::Result<()> {
+        for ph in headers {
+            // タイプ
+            let ph_type = match ph.r#type {
+                segument::Type::Null => 0,
+                segument::Type::Load => 1,
+                segument::Type::Dynamic => 2,
+                segument::Type::Interp => 3,
+                segument::Type::Note => 4,
+                segument::Type::ShLib => 5,
+                segument::Type::Phdr => 6,
+                segument::Type::Tls => 7,
+                segument::Type::Num => 8,
+                // 以下のタイプは特殊な値を持つので、直接数値を指定
+                segument::Type::LoOs => 0x60000000,
+                segument::Type::GnuEhFrame => 0x6474e550,
+                segument::Type::GnuStack => 0x6474e551,
+                segument::Type::GnuRelro => 0x6474e552,
+                segument::Type::SunwBss => 0x6ffffffa,
+                segument::Type::SunwStack => 0x6ffffffb,
+                segument::Type::HiOs => 0x6fffffff,
+                segument::Type::LoProc => 0x70000000,
+                segument::Type::HiProc => 0x7fffffff,
+            };
+            file.write_all(&(ph_type as u32).to_le_bytes())?;
+
+            // フラグ
+            let mut flags: u32 = 0;
+            for flag in &ph.flags {
+                let bit = match flag {
+                    segument::Flag::Executable => 0x1,
+                    segument::Flag::Writable => 0x2,
+                    segument::Flag::Readable => 0x4,
+                    segument::Flag::MaskOS | segument::Flag::MaskProc => {
+                        // これらはマスク値なので、通常は直接使用しない
+                        continue;
+                    }
+                };
+                flags |= bit;
+            }
+            file.write_all(&flags.to_le_bytes())?;
+
+            // ファイルオフセット
+            file.write_all(&ph.offset.to_le_bytes())?;
+
+            // 仮想アドレス
+            file.write_all(&ph.vaddr.to_le_bytes())?;
+
+            // 物理アドレス
+            file.write_all(&ph.paddr.to_le_bytes())?;
+
+            // ファイルサイズ
+            file.write_all(&ph.filesz.to_le_bytes())?;
+
+            // メモリサイズ
+            file.write_all(&ph.memsz.to_le_bytes())?;
+
+            // アラインメント
+            file.write_all(&ph.align.to_le_bytes())?;
+        }
+
+        Ok(())
+    }
+
+    /// セクションデータをファイルに書き込む
+    fn write_sections(&self, file: &mut fs::File, sections: &[OutputSection]) -> io::Result<()> {
+        for section in sections {
+            // ファイルポインタをセクションのオフセット位置に移動
+            file.seek(SeekFrom::Start(section.offset))?;
+
+            // セクションデータを書き込み
+            file.write_all(&section.data)?;
+        }
+
+        Ok(())
+    }
+
+    /// リンク処理全体を実行する
+    pub fn link(&self) -> Result<Vec<OutputSection>, String> {
+        // 1. シンボル解決を実行
+        let (mut resolved_symbols, unresolved_symbols) = self.resolve_symbols();
+
+        // 未解決シンボルがあればエラー
+        if !unresolved_symbols.is_empty() {
+            return Err(format!(
+                "未解決のシンボルがあります: {:?}",
+                unresolved_symbols
+            ));
+        }
+
+        // 2. セクション配置を実行
+        let mut output_sections = self.layout_sections(&mut resolved_symbols);
+
+        // 3. 再配置処理を適用
+        self.apply_relocations(&mut output_sections, &resolved_symbols)?;
+
+        Ok(output_sections)
+    }
+
+    /// 読み込まれたオブジェクトファイルの数を返す
+    pub fn object_count(&self) -> usize {
+        self.objects.len()
+    }
+
+    /// 指定されたシンボルがオブジェクトファイル内に存在するかチェック
+    pub fn has_symbol(&self, name: &str) -> bool {
+        for obj in &self.objects {
+            for symbol in &obj.symbols {
+                if symbol.name == name {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// 指定されたシンボルが未定義シンボルとして参照されているかチェック
+    pub fn has_undefined_symbol(&self, name: &str) -> bool {
+        for obj in &self.objects {
+            for symbol in &obj.symbols {
+                if symbol.name == name && symbol.shndx == 0 {
+                    // shndx == 0 は SHN_UNDEF を意味し、未定義シンボル
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// シンボル解決を行い、解決されたシンボルと未解決シンボルを返す
+    pub fn resolve_symbols(&self) -> (HashMap<String, ResolvedSymbol>, Vec<String>) {
+        let mut resolved_symbols: HashMap<String, ResolvedSymbol> = HashMap::new();
+
+        // 各オブジェクトファイルのシンボルを処理
+        for (obj_idx, obj) in self.objects.iter().enumerate() {
+            for symbol in &obj.symbols {
+                let is_defined = symbol.shndx != 0; // 0 = SHN_UNDEF (未定義シンボル)
+
+                // シンボル名が空の場合はスキップ（NULL シンボル）
+                if symbol.name.is_empty() {
+                    continue;
+                }
+
+                let new_symbol = ResolvedSymbol {
+                    name: symbol.name.clone(),
+                    value: symbol.value,
+                    size: symbol.size,
+                    r#type: symbol.info.r#type,
+                    binding: symbol.info.binding,
+                    section_index: symbol.shndx,
+                    object_index: obj_idx,
+                    is_defined,
+                };
+
+                // 既存のシンボルとマージするかどうかを決定
+                if let Some(existing) = resolved_symbols.get(&symbol.name) {
+                    // 両方定義済みの場合、バインディングの強さでどちらを使うか決める
+                    if is_defined && existing.is_defined {
+                        if new_symbol.is_stronger_than(existing) {
+                            resolved_symbols.insert(symbol.name.clone(), new_symbol);
+                        }
+                        // 既存のシンボルの方が強いか同等なら、それを保持
+                    }
+                    // 現在が定義済みで既存が未定義なら、今回の定義で上書き
+                    else if is_defined && !existing.is_defined {
+                        resolved_symbols.insert(symbol.name.clone(), new_symbol);
+                    }
+                    // それ以外の場合は既存を保持
+                } else {
+                    // まだ見たことのないシンボルは追加
+                    resolved_symbols.insert(symbol.name.clone(), new_symbol);
+                }
+            }
+        }
+
+        // 未解決シンボルをチェック
+        let unresolved_symbols: Vec<String> = resolved_symbols
+            .iter()
+            .filter(|(_, symbol)| !symbol.is_defined)
+            .map(|(name, _)| name.clone())
+            .collect();
+
+        (resolved_symbols, unresolved_symbols)
+    }
+
+    /// セクションの配置を行い、出力セクションのリストを返す
+    pub fn layout_sections(
+        &self,
+        resolved_symbols: &mut HashMap<String, ResolvedSymbol>,
+    ) -> Vec<OutputSection> {
+        let mut output_sections: Vec<OutputSection> = Vec::new();
+
+        // .textセクションと.dataセクションを統合し、オフセット情報を取得
+        let (text_data, text_offsets) = self.merge_sections(".text", 1);
+        let (data_data, data_offsets) = self.merge_sections(".data", 2);
+
+        // 基本的なメモリレイアウトを決定
+        // まず.textセクションから設定
+        let base_addr = 0x400000; // 実行可能ファイルの典型的な開始アドレス
+        let text_section = OutputSection {
+            name: ".text".to_string(),
+            r#type: section::SectionType::ProgBits,
+            flags: vec![section::SectionFlag::Alloc, section::SectionFlag::ExecInstr],
+            addr: base_addr + 0x1000, // 修正: テキストセクションの開始アドレスを0x401000に変更
+            offset: 0x1000,           // ヘッダーの後のオフセット
+            size: text_data.len() as u64,
+            data: text_data,
+            align: 0x1000, // 一般的なページサイズ
+        };
+
+        // .dataセクションは.textの後に配置
+        let data_addr = align(base_addr + 0x2000, 0x1000); // 修正: 明示的に0x402000に配置
+        let data_section = OutputSection {
+            name: ".data".to_string(),
+            r#type: section::SectionType::ProgBits,
+            flags: vec![section::SectionFlag::Alloc, section::SectionFlag::Write],
+            addr: data_addr,
+            offset: 0x2000, // 修正: 明示的に0x2000に設定
+            size: data_data.len() as u64,
+            data: data_data,
+            align: 0x1000,
+        };
+
+        // 出力セクションリストを構築
+        output_sections.push(text_section);
+        output_sections.push(data_section);
+
+        // シンボルのアドレスを更新
+        self.update_symbol_addresses(
+            resolved_symbols,
+            &text_offsets,
+            base_addr + 0x1000,
+            &data_offsets,
+            data_addr,
+        );
+
+        output_sections
+    }
+
+    /// 指定された名前のセクションをすべてのオブジェクトファイルから統合し、
+    /// 元のオフセット情報と統合されたデータを返す
+    fn merge_sections(
+        &self,
+        section_name: &str,
+        section_index: u16,
+    ) -> (Vec<u8>, HashMap<(usize, u16), usize>) {
+        let mut section_data: Vec<u8> = Vec::new();
+        let mut offsets: HashMap<(usize, u16), usize> = HashMap::new();
+        let mut current_offset = 0;
+
+        for (obj_idx, obj) in self.objects.iter().enumerate() {
+            for section in &obj.section_headers {
+                if section.name == section_name {
+                    // このオブジェクトのセクションの開始オフセットを記録
+                    offsets.insert((obj_idx, section_index), current_offset);
+                    section_data.extend_from_slice(&section.data);
+                    current_offset += section.data.len();
+                }
+            }
+        }
+
+        (section_data, offsets)
+    }
+
+    /// シンボルの最終アドレスを更新する
+    fn update_symbol_addresses(
+        &self,
+        resolved_symbols: &mut HashMap<String, ResolvedSymbol>,
+        text_offsets: &HashMap<(usize, u16), usize>,
+        text_base_addr: u64,
+        data_offsets: &HashMap<(usize, u16), usize>,
+        data_base_addr: u64,
+    ) {
+        for symbol in resolved_symbols.values_mut() {
+            if !symbol.is_defined {
+                continue; // 未定義シンボルはスキップ
+            }
+
+            // シンボルのセクションインデックスに応じて適切なベースアドレスを選択
+            match symbol.section_index {
+                1 => {
+                    // .textセクション内のシンボル
+                    if let Some(&offset) =
+                        text_offsets.get(&(symbol.object_index, symbol.section_index))
+                    {
+                        // オブジェクトファイル内でのオフセット + 統合.textセクションでのオブジェクトのオフセット + .textセクションの開始アドレス
+                        symbol.value = text_base_addr + (offset + symbol.value as usize) as u64;
+                    }
+                }
+                2 => {
+                    // .dataセクション内のシンボル
+                    if let Some(&offset) =
+                        data_offsets.get(&(symbol.object_index, symbol.section_index))
+                    {
+                        // オブジェクトファイル内でのオフセット + 統合.dataセクションでのオブジェクトのオフセット + .dataセクションの開始アドレス
+                        symbol.value = data_base_addr + (offset + symbol.value as usize) as u64;
+                    }
+                }
+                _ => {
+                    // その他のセクション（現状は無視）
+                }
+            }
+        }
+    }
+
+    /// 再配置（リロケーション）を適用する
+    ///
+    /// 各オブジェクトファイルの再配置エントリを処理し、
+    /// 解決されたシンボルのアドレスを使用して参照を更新する
+    pub fn apply_relocations(
+        &self,
+        output_sections: &mut [OutputSection],
+        resolved_symbols: &HashMap<String, ResolvedSymbol>,
+    ) -> Result<(), String> {
+        // セクション名からOutputSectionの位置を特定するマップ
+        let section_indices: HashMap<String, usize> = output_sections
+            .iter()
+            .enumerate()
+            .map(|(i, sec)| (sec.name.clone(), i))
+            .collect();
+
+        // 各オブジェクトファイルの再配置エントリを処理
+        for (obj_idx, obj) in self.objects.iter().enumerate() {
+            // 各再配置エントリに対して処理を行う
+            for reloc in &obj.relocations {
+                // 再配置タイプに応じた処理
+                self.process_relocation(
+                    obj_idx,
+                    reloc,
+                    output_sections,
+                    &section_indices,
+                    resolved_symbols,
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// 個々の再配置エントリを処理する
+    fn process_relocation(
+        &self,
+        obj_idx: usize,
+        reloc: &relocation::RelocationAddend,
+        output_sections: &mut [OutputSection],
+        section_indices: &HashMap<String, usize>,
+        resolved_symbols: &HashMap<String, ResolvedSymbol>,
+    ) -> Result<(), String> {
+        // 再配置タイプに応じた処理
+        match reloc.info.r#type {
+            relocation::RelocationType::Aarch64AdrPrelLo21 => {
+                // シンボルインデックスからシンボル名を取得
+                let symbol_index = reloc.info.symbol_index as usize;
+                if symbol_index >= self.objects[obj_idx].symbols.len() {
+                    return Err(format!("シンボルインデックスが範囲外: {}", symbol_index));
+                }
+
+                let symbol_name = &self.objects[obj_idx].symbols[symbol_index].name;
+
+                // 解決されたシンボルを取得
+                let resolved_symbol = resolved_symbols
+                    .get(symbol_name)
+                    .ok_or_else(|| format!("シンボルが解決されていません: {}", symbol_name))?;
+
+                // シンボルが未定義の場合はエラー
+                if !resolved_symbol.is_defined {
+                    return Err(format!("未定義シンボルへの再配置: {}", symbol_name));
+                }
+
+                // 再配置が適用されるセクション（通常は.text）のインデックスを取得
+                let text_section_idx = section_indices
+                    .get(".text")
+                    .ok_or_else(|| "再配置対象セクションが見つかりません: .text".to_string())?;
+
+                // セクションへの可変参照を取得
+                let target_section = &mut output_sections[*text_section_idx];
+
+                // 再配置オフセットが範囲内かチェック
+                if reloc.offset as usize >= target_section.data.len() {
+                    return Err(format!("再配置オフセットが範囲外: {}", reloc.offset));
+                }
+
+                // AArch64 ADR_PREL_LO21 再配置の適用
+                // リロケーションのオフセット位置にシンボルの相対アドレスを書き込む
+                let instruction_addr = target_section.addr + reloc.offset;
+                let symbol_addr = resolved_symbol.value;
+
+                // シンボルとの相対アドレスを計算 (ターゲットアドレス - PC値)
+                // PCは現在の命令アドレス（instruction_addr）
+                let relative_addr =
+                    ((symbol_addr as i64) - (instruction_addr as i64) + reloc.addend) as i32;
+
+                // ADR命令の形式にエンコード
+                // 現在の命令を取得
+                let pos = reloc.offset as usize;
+                let instruction = u32::from_le_bytes([
+                    target_section.data[pos],
+                    target_section.data[pos + 1],
+                    target_section.data[pos + 2],
+                    target_section.data[pos + 3],
+                ]);
+
+                // ADR命令のオペコードとレジスタ部分を保持
+                // ADR命令のフォーマット: 0bxxx10000 iiiiiiii iiiiiiii iiiddddd
+                // x: opcode, i: immbit, d: destination register
+                let opcode_rd = instruction & 0x9F00001F; // オペコードとレジスタ部分を保持
+
+                // ADR命令のエンコーディング（ARMv8アーキテクチャリファレンスマニュアルに基づく）
+                // immhi: upper 19 bits of immediate (bits 5-23)
+                // immlo: lower 2 bits of immediate (bits 29-30)
+                let immlo = ((relative_addr & 0x3) as u32) << 29;
+                let immhi = (((relative_addr >> 2) & 0x7FFFF) as u32) << 5;
+
+                // 新しい命令を構築
+                let new_instruction = opcode_rd | immlo | immhi;
+
+                // 更新された命令をセクションデータに書き戻す
+                let instruction_bytes = new_instruction.to_le_bytes();
+                target_section.data[pos] = instruction_bytes[0];
+                target_section.data[pos + 1] = instruction_bytes[1];
+                target_section.data[pos + 2] = instruction_bytes[2];
+                target_section.data[pos + 3] = instruction_bytes[3];
+            }
+        }
+
+        Ok(())
+    }
+
+    /// シンボルテーブルエントリを書き込む
+    fn write_symbol_entry(
+        &self,
+        data: &mut Vec<u8>,
+        st_name: u32,
+        st_value: u64,
+        st_size: u64,
+        st_info: u8,
+        st_other: u8,
+        st_shndx: u16,
+    ) {
+        // シンボル名のインデックス
+        data.extend_from_slice(&st_name.to_le_bytes());
+
+        // シンボル情報（バインディングとタイプ）
+        data.push(st_info);
+
+        // その他の情報
+        data.push(st_other);
+
+        // セクションインデックス
+        data.extend_from_slice(&st_shndx.to_le_bytes());
+
+        // シンボル値（アドレス）
+        data.extend_from_slice(&st_value.to_le_bytes());
+
+        // シンボルサイズ
+        data.extend_from_slice(&st_size.to_le_bytes());
+    }
+
+    /// セクションヘッダーを書き込む
+    fn write_section_header(
+        &self,
+        file: &mut fs::File,
+        name: u32,
+        _debug_name: &str,
+        sh_type: u32,
+        sh_flags: u64,
+        sh_addr: u64,
+        sh_offset: u64,
+        sh_size: u64,
+        sh_link: u32,
+        sh_info: u32,
+        sh_addralign: u64,
+        sh_entsize: u64,
+    ) -> io::Result<()> {
+        // セクション名のインデックス
+        file.write_all(&name.to_le_bytes())?;
+
+        // セクションタイプ
+        file.write_all(&sh_type.to_le_bytes())?;
+
+        // セクションフラグ
+        file.write_all(&sh_flags.to_le_bytes())?;
+
+        // メモリ上のアドレス
+        file.write_all(&sh_addr.to_le_bytes())?;
+
+        // ファイル内オフセット
+        file.write_all(&sh_offset.to_le_bytes())?;
+
+        // セクションサイズ
+        file.write_all(&sh_size.to_le_bytes())?;
+
+        // リンク情報
+        file.write_all(&sh_link.to_le_bytes())?;
+
+        // 追加情報
+        file.write_all(&sh_info.to_le_bytes())?;
+
+        // アライメント
+        file.write_all(&sh_addralign.to_le_bytes())?;
+
+        // エントリサイズ (固定サイズのテーブルの場合)
+        file.write_all(&sh_entsize.to_le_bytes())?;
+
+        Ok(())
+    }
+}
+
+/// 値をアラインメントに合わせる
+fn align(value: u64, alignment: u64) -> u64 {
+    (value + alignment - 1) & !(alignment - 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use std::path::Path;
+
+    #[test]
+    fn test_basic_linker_creation() {
+        // テスト対象のオブジェクトファイルのパス
+        let main_o = Path::new("src/parser/fixtures/main.o");
+        let sub_o = Path::new("src/parser/fixtures/sub.o");
+
+        // オブジェクトファイルが存在することを確認
+        assert!(main_o.exists(), "main.o が見つかりません");
+        assert!(sub_o.exists(), "sub.o が見つかりません");
+
+        // リンカーを作成
+        let linker = Linker::new();
+
+        // オブジェクトファイルを追加
+        let linker = linker.add_object(main_o).expect("main.o の追加に失敗");
+        let linker = linker.add_object(sub_o).expect("sub.o の追加に失敗");
+
+        // オブジェクトファイルが正しく読み込まれているか
+        assert_eq!(linker.object_count(), 2, "オブジェクトファイルの数が不正");
+    }
+
+    #[test]
+    fn test_basic_object_parsing() {
+        // テスト対象のオブジェクトファイル
+        let main_o = Path::new("src/parser/fixtures/main.o");
+
+        // リンカーを作成してオブジェクトを追加
+        let linker = Linker::new()
+            .add_object(main_o)
+            .expect("main.o の追加に失敗");
+
+        // main.o から _start シンボルが見つかるか確認
+        let has_start = linker.has_symbol("_start");
+        assert!(has_start, "_start シンボルが見つかりません");
+
+        // main.o から未定義シンボル x が見つかるか確認
+        let uses_x = linker.has_undefined_symbol("x");
+        assert!(uses_x, "未定義シンボル x が見つかりません");
+    }
+
+    #[test]
+    fn test_symbol_resolution() {
+        // main.o と sub.o を読み込む
+        let main_o = Path::new("src/parser/fixtures/main.o");
+        let sub_o = Path::new("src/parser/fixtures/sub.o");
+
+        let linker = Linker::new()
+            .add_object(main_o)
+            .expect("main.o の読み込み失敗")
+            .add_object(sub_o)
+            .expect("sub.o の読み込み失敗");
+
+        // シンボル解決を実行
+        let (resolved_symbols, unresolved_symbols) = linker.resolve_symbols();
+
+        // 全てのシンボルが解決されていることを確認
+        assert!(
+            unresolved_symbols.is_empty(),
+            "未解決のシンボルがあります: {:?}",
+            unresolved_symbols
+        );
+
+        // '_start'と'x'シンボルが解決されていることを確認
+        assert!(
+            resolved_symbols.contains_key("_start"),
+            "_start シンボルが解決されていません"
+        );
+        assert!(
+            resolved_symbols.contains_key("x"),
+            "x シンボルが解決されていません"
+        );
+
+        // 'x'シンボルが適切に解決されているか確認
+        // 'x'はsub.oで定義され、値は23になっているはず
+        if let Some(x_symbol) = resolved_symbols.get("x") {
+            // sub.oから来ているかチェック（オブジェクトインデックスは1であるべき）
+            assert_eq!(x_symbol.object_index, 1, "x シンボルのオブジェクト元が不正");
+        } else {
+            panic!("x シンボルが見つかりません");
+        }
+    }
+
+    #[test]
+    fn test_section_layout() {
+        // main.o と sub.o を読み込む
+        let main_o = Path::new("src/parser/fixtures/main.o");
+        let sub_o = Path::new("src/parser/fixtures/sub.o");
+
+        let linker = Linker::new()
+            .add_object(main_o)
+            .expect("main.o の読み込み失敗")
+            .add_object(sub_o)
+            .expect("sub.o の読み込み失敗");
+
+        // シンボル解決を実行
+        let (mut resolved_symbols, _) = linker.resolve_symbols();
+
+        // セクション配置を実行
+        let output_sections = linker.layout_sections(&mut resolved_symbols);
+
+        // 必要なセクションが存在するか確認
+        assert!(
+            output_sections.iter().any(|s| s.name == ".text"),
+            ".text セクションがありません"
+        );
+        assert!(
+            output_sections.iter().any(|s| s.name == ".data"),
+            ".data セクションがありません"
+        );
+
+        // セクションの順序が正しいか確認 (.text -> .data)
+        let text_idx = output_sections
+            .iter()
+            .position(|s| s.name == ".text")
+            .unwrap();
+        let data_idx = output_sections
+            .iter()
+            .position(|s| s.name == ".data")
+            .unwrap();
+        assert!(
+            text_idx < data_idx,
+            "セクションの順序が不正: .text は .data より前にあるべき"
+        );
+
+        // .textセクションが実行可能属性を持っているか確認
+        let text_section = &output_sections[text_idx];
+        assert!(
+            text_section
+                .flags
+                .contains(&section::SectionFlag::ExecInstr),
+            ".text セクションに実行可能フラグがありません"
+        );
+
+        // .dataセクションが書き込み可能属性を持っているか確認
+        let data_section = &output_sections[data_idx];
+        assert!(
+            data_section.flags.contains(&section::SectionFlag::Write),
+            ".data セクションに書き込み可能フラグがありません"
+        );
+
+        // セクションのアドレスが適切に割り当てられているか確認
+        assert!(text_section.addr > 0, ".text セクションのアドレスが不正");
+        assert!(
+            data_section.addr > text_section.addr,
+            ".data セクションは .text セクションの後に配置されるべき"
+        );
+
+        // アドレスの具体的な値をチェック
+        assert_eq!(
+            text_section.addr, 0x400000,
+            ".text セクションの開始アドレスが期待値と異なります"
+        );
+        // .dataセクションは.textセクションの後、アラインメントされた位置に配置されるはず
+        let expected_data_addr = align(text_section.addr + text_section.size, 0x1000);
+        assert_eq!(
+            data_section.addr, expected_data_addr,
+            ".data セクションの開始アドレスが期待値と異なります"
+        );
+
+        // セクションのサイズが適切か確認
+        assert!(text_section.size > 0, ".text セクションのサイズが不正");
+        assert!(data_section.size > 0, ".data セクションのサイズが不正");
+
+        // xシンボルのアドレスが.dataセクション内にあるか確認
+        let x_symbol = resolved_symbols.get("x").unwrap();
+        assert!(
+            x_symbol.value >= data_section.addr
+                && x_symbol.value < data_section.addr + data_section.size,
+            "xシンボルのアドレスが.dataセクション内にありません"
+        );
+
+        // _startシンボルが.textセクション内にあるか確認
+        let start_symbol = resolved_symbols.get("_start").unwrap();
+        assert!(
+            start_symbol.value >= text_section.addr
+                && start_symbol.value < text_section.addr + text_section.size,
+            "_startシンボルのアドレスが.textセクション内にありません"
+        );
+
+        // シンボルのアドレスが適切に更新されているか確認
+        // _startシンボルは.textセクションの先頭に配置されるべき
+        let expected_start_addr = text_section.addr;
+        assert_eq!(
+            start_symbol.value, expected_start_addr,
+            "_startシンボルのアドレスが期待値と異なります"
+        );
+
+        // xシンボルは.dataセクションの先頭に配置されるべき
+        let expected_x_addr = data_section.addr;
+        assert_eq!(
+            x_symbol.value, expected_x_addr,
+            "xシンボルのアドレスが期待値と異なります"
+        );
+    }
+
+    #[test]
+    fn test_apply_relocations() {
+        // main.o と sub.o を読み込む
+        let main_o = Path::new("src/parser/fixtures/main.o");
+        let sub_o = Path::new("src/parser/fixtures/sub.o");
+
+        let linker = Linker::new()
+            .add_object(main_o)
+            .expect("main.o の読み込み失敗")
+            .add_object(sub_o)
+            .expect("sub.o の読み込み失敗");
+
+        // リンク処理を実行
+        let output_sections = linker.link().expect("リンク処理に失敗");
+
+        // .text セクションを見つける
+        let text_section = output_sections
+            .iter()
+            .find(|s| s.name == ".text")
+            .expect(".text セクションが見つかりません");
+
+        // 実行可能ビットが設定されていることを確認
+        assert!(
+            text_section
+                .flags
+                .contains(&section::SectionFlag::ExecInstr),
+            ".text セクションに実行可能フラグがありません"
+        );
+
+        // main.o に含まれる再配置エントリによって .text セクションの命令が更新されたことを確認
+        // 特定のオフセットにある命令を検査
+        let offset = 0; // 最初の再配置エントリのオフセット
+        assert!(
+            offset + 4 <= text_section.data.len(),
+            "命令のオフセットが範囲外"
+        );
+
+        // 命令データを取得
+        let instruction = u32::from_le_bytes([
+            text_section.data[offset],
+            text_section.data[offset + 1],
+            text_section.data[offset + 2],
+            text_section.data[offset + 3],
+        ]);
+
+        // 更新された命令のアドレスフィールドをチェック
+        // 命令の形式はADRで、下位21ビットが相対アドレスを格納
+        let addr_field = instruction & 0x1FFFFF;
+
+        // アドレスフィールドが0でないことを確認
+        // 実際の値は環境によって異なるので、詳細な値のチェックはしない
+        assert!(
+            addr_field != 0,
+            "再配置によるアドレス更新が行われていません"
+        );
+    }
+}

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -393,67 +393,51 @@ impl Linker {
 
     /// ELFヘッダーをファイルに書き込む
     fn write_elf_header(&self, file: &mut fs::File, header: &header::Header) -> io::Result<()> {
-        // ELF マジックナンバー
-        file.write_all(&[0x7f, b'E', b'L', b'F'])?;
+        let bytes = [
+            // ELF マジックナンバー
+            &[0x7f, b'E', b'L', b'F'],
+            // ELFクラス（32/64ビット）
+            [header.ident.class as u8].as_slice(),
+            // エンディアン
+            [header.ident.data as u8].as_slice(),
+            // バージョン
+            [header.ident.version as u8].as_slice(),
+            // OS ABI
+            [header.ident.os_abi as u8].as_slice(),
+            // ABI バージョン
+            [header.ident.abi_version].as_slice(),
+            // パディング
+            [0; 7].as_slice(),
+            // タイプ
+            (header.r#type as u16).to_le_bytes().as_slice(),
+            // マシン
+            (header.machine as u16).to_le_bytes().as_slice(),
+            // バージョン（拡張）
+            (header.version as u32).to_le_bytes().as_slice(),
+            // エントリポイント
+            header.entry.to_le_bytes().as_slice(),
+            // プログラムヘッダーオフセット
+            header.phoff.to_le_bytes().as_slice(),
+            // セクションヘッダーオフセット
+            header.shoff.to_le_bytes().as_slice(),
+            // フラグ
+            header.flags.to_le_bytes().as_slice(),
+            // ELFヘッダーサイズ
+            header.ehsize.to_le_bytes().as_slice(),
+            // プログラムヘッダーエントリサイズ
+            header.phentsize.to_le_bytes().as_slice(),
+            // プログラムヘッダー数
+            header.phnum.to_le_bytes().as_slice(),
+            // セクションヘッダーエントリサイズ
+            header.shentsize.to_le_bytes().as_slice(),
+            // セクションヘッダー数
+            header.shnum.to_le_bytes().as_slice(),
+            // セクション名文字列テーブルのインデックス
+            header.shstrndx.to_le_bytes().as_slice(),
+        ]
+        .concat();
 
-        // ELFクラス（32/64ビット）
-        file.write_all(&[header.ident.class as u8])?;
-
-        // エンディアン
-        file.write_all(&[header.ident.data as u8])?;
-
-        // バージョン
-        file.write_all(&[header.ident.version as u8])?;
-
-        // OS ABI
-        file.write_all(&[header.ident.os_abi as u8])?;
-
-        // ABI バージョン
-        file.write_all(&[header.ident.abi_version])?;
-
-        // パディング
-        file.write_all(&[0; 7])?;
-
-        // タイプ
-        file.write_all(&(header.r#type as u16).to_le_bytes())?;
-
-        // マシン
-        file.write_all(&(header.machine as u16).to_le_bytes())?;
-
-        // バージョン（拡張）
-        file.write_all(&(header.version as u32).to_le_bytes())?;
-
-        // エントリポイント
-        file.write_all(&header.entry.to_le_bytes())?;
-
-        // プログラムヘッダーオフセット
-        file.write_all(&header.phoff.to_le_bytes())?;
-
-        // セクションヘッダーオフセット
-        file.write_all(&header.shoff.to_le_bytes())?;
-
-        // フラグ
-        file.write_all(&header.flags.to_le_bytes())?;
-
-        // ELFヘッダーサイズ
-        file.write_all(&header.ehsize.to_le_bytes())?;
-
-        // プログラムヘッダーエントリサイズ
-        file.write_all(&header.phentsize.to_le_bytes())?;
-
-        // プログラムヘッダー数
-        file.write_all(&header.phnum.to_le_bytes())?;
-
-        // セクションヘッダーエントリサイズ
-        file.write_all(&header.shentsize.to_le_bytes())?;
-
-        // セクションヘッダー数
-        file.write_all(&header.shnum.to_le_bytes())?;
-
-        // セクション名文字列テーブルのインデックス
-        file.write_all(&header.shstrndx.to_le_bytes())?;
-
-        Ok(())
+        file.write_all(&bytes)
     }
 
     /// プログラムヘッダーをファイルに書き込む
@@ -910,37 +894,21 @@ impl Linker {
         sh_addralign: u64,
         sh_entsize: u64,
     ) -> io::Result<()> {
-        // セクション名のインデックス
-        file.write_all(&name.to_le_bytes())?;
+        let bytes = [
+            name.to_le_bytes().as_slice(),         // セクション名のインデックス
+            sh_type.to_le_bytes().as_slice(),      // セクションタイプ
+            sh_flags.to_le_bytes().as_slice(),     // セクションフラグ
+            sh_addr.to_le_bytes().as_slice(),      // メモリ上のアドレス
+            sh_offset.to_le_bytes().as_slice(),    // ファイル内オフセット
+            sh_size.to_le_bytes().as_slice(),      // セクションサイズ
+            sh_link.to_le_bytes().as_slice(),      // リンク情報
+            sh_info.to_le_bytes().as_slice(),      // 追加情報
+            sh_addralign.to_le_bytes().as_slice(), // アライメント
+            sh_entsize.to_le_bytes().as_slice(),   // エントリサイズ
+        ]
+        .concat();
 
-        // セクションタイプ
-        file.write_all(&sh_type.to_le_bytes())?;
-
-        // セクションフラグ
-        file.write_all(&sh_flags.to_le_bytes())?;
-
-        // メモリ上のアドレス
-        file.write_all(&sh_addr.to_le_bytes())?;
-
-        // ファイル内オフセット
-        file.write_all(&sh_offset.to_le_bytes())?;
-
-        // セクションサイズ
-        file.write_all(&sh_size.to_le_bytes())?;
-
-        // リンク情報
-        file.write_all(&sh_link.to_le_bytes())?;
-
-        // 追加情報
-        file.write_all(&sh_info.to_le_bytes())?;
-
-        // アライメント
-        file.write_all(&sh_addralign.to_le_bytes())?;
-
-        // エントリサイズ (固定サイズのテーブルの場合)
-        file.write_all(&sh_entsize.to_le_bytes())?;
-
-        Ok(())
+        file.write_all(&bytes)
     }
 }
 

--- a/src/linker.rs
+++ b/src/linker.rs
@@ -1352,7 +1352,7 @@ mod tests {
 
         // アドレスの具体的な値をチェック
         assert_eq!(
-            text_section.addr, 0x400000,
+            text_section.addr, 0x401000,
             ".text セクションの開始アドレスが期待値と異なります"
         );
         // .dataセクションは.textセクションの後、アラインメントされた位置に配置されるはず

--- a/src/linker/output.rs
+++ b/src/linker/output.rs
@@ -19,7 +19,7 @@ pub struct ResolvedSymbol {
     pub size: u64,
     pub r#type: symbol::Type,
     pub binding: symbol::Binding,
-    pub section_index: u16,
+    pub shndx: u16,
     pub object_index: usize,
     pub is_defined: bool,
 }

--- a/src/linker/output.rs
+++ b/src/linker/output.rs
@@ -1,0 +1,38 @@
+use crate::elf::{section, symbol};
+
+#[derive(Debug, Clone)]
+pub struct Section {
+    pub name: String,
+    pub r#type: section::SectionType,
+    pub flags: Vec<section::SectionFlag>,
+    pub addr: u64,
+    pub offset: u64,
+    pub size: u64,
+    pub data: Vec<u8>,
+    pub align: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolvedSymbol {
+    pub name: String,
+    pub value: u64,
+    pub size: u64,
+    pub r#type: symbol::Type,
+    pub binding: symbol::Binding,
+    pub section_index: u16,
+    pub object_index: usize,
+    pub is_defined: bool,
+}
+
+impl ResolvedSymbol {
+    pub fn is_stronger_than(&self, other: &Self) -> bool {
+        match (self.binding, other.binding) {
+            (symbol::Binding::Local, _) => true,
+            (_, symbol::Binding::Weak) => true,
+            (symbol::Binding::Global, symbol::Binding::Global) => false,
+            (symbol::Binding::Global, symbol::Binding::Local) => false,
+            (symbol::Binding::Weak, _) => false,
+            _ => false,
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,37 +6,40 @@ use yui::linker::Linker;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    
+
     if args.len() < 3 {
-        eprintln!("使用方法: {} <出力ファイル> <入力オブジェクトファイル1> [<入力オブジェクトファイル2> ...]", args[0]);
+        eprintln!(
+            "使用方法: {} <出力ファイル> <入力オブジェクトファイル1> [<入力オブジェクトファイル2> ...]",
+            args[0]
+        );
         process::exit(1);
     }
-    
+
     let output_path = Path::new(&args[1]);
     let input_paths: Vec<&Path> = args[2..].iter().map(|s| Path::new(s)).collect();
-    
+
     // リンカーを初期化
     let mut linker = Linker::new();
-    
+
     // 入力オブジェクトファイルを追加
     for input_path in input_paths {
         match linker.add_object(input_path) {
             Ok(l) => {
                 linker = l;
                 println!("オブジェクトファイルを追加: {}", input_path.display());
-            },
+            }
             Err(e) => {
                 eprintln!("エラー: {} の読み込みに失敗: {}", input_path.display(), e);
                 process::exit(1);
             }
         }
     }
-    
+
     // リンク処理を実行し、出力ファイルを生成
     match linker.link_to_file(output_path) {
         Ok(_) => {
             println!("リンク成功: {}", output_path.display());
-        },
+        }
         Err(e) => {
             eprintln!("リンクエラー: {}", e);
             process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ fn main() {
     }
 
     let output_path = Path::new(&args[1]);
-    let input_paths: Vec<&Path> = args[2..].iter().map(|s| Path::new(s)).collect();
+    let input_paths: Vec<&Path> = args[2..].iter().map(Path::new).collect();
 
     // リンカーを初期化
     let mut linker = Linker::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,45 +4,19 @@ use std::process;
 
 use yui::linker::Linker;
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = env::args().collect();
 
     if args.len() < 3 {
-        eprintln!(
-            "使用方法: {} <出力ファイル> <入力オブジェクトファイル1> [<入力オブジェクトファイル2> ...]",
-            args[0]
-        );
+        eprintln!("Usage: {} <output> <input1> [<input2> ...]", args[0]);
         process::exit(1);
     }
 
     let output_path = Path::new(&args[1]);
     let input_paths: Vec<&Path> = args[2..].iter().map(Path::new).collect();
 
-    // リンカーを初期化
     let mut linker = Linker::new();
 
-    // 入力オブジェクトファイルを追加
-    for input_path in input_paths {
-        match linker.add_object(input_path) {
-            Ok(l) => {
-                linker = l;
-                println!("オブジェクトファイルを追加: {}", input_path.display());
-            }
-            Err(e) => {
-                eprintln!("エラー: {} の読み込みに失敗: {}", input_path.display(), e);
-                process::exit(1);
-            }
-        }
-    }
-
-    // リンク処理を実行し、出力ファイルを生成
-    match linker.link_to_file(output_path) {
-        Ok(_) => {
-            println!("リンク成功: {}", output_path.display());
-        }
-        Err(e) => {
-            eprintln!("リンクエラー: {}", e);
-            process::exit(1);
-        }
-    }
+    linker.link_to_file(output_path, &input_paths)?;
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,45 @@
+use std::env;
+use std::path::Path;
+use std::process;
+
+use yui::linker::Linker;
+
 fn main() {
-    println!("Hello, world!");
+    let args: Vec<String> = env::args().collect();
+    
+    if args.len() < 3 {
+        eprintln!("使用方法: {} <出力ファイル> <入力オブジェクトファイル1> [<入力オブジェクトファイル2> ...]", args[0]);
+        process::exit(1);
+    }
+    
+    let output_path = Path::new(&args[1]);
+    let input_paths: Vec<&Path> = args[2..].iter().map(|s| Path::new(s)).collect();
+    
+    // リンカーを初期化
+    let mut linker = Linker::new();
+    
+    // 入力オブジェクトファイルを追加
+    for input_path in input_paths {
+        match linker.add_object(input_path) {
+            Ok(l) => {
+                linker = l;
+                println!("オブジェクトファイルを追加: {}", input_path.display());
+            },
+            Err(e) => {
+                eprintln!("エラー: {} の読み込みに失敗: {}", input_path.display(), e);
+                process::exit(1);
+            }
+        }
+    }
+    
+    // リンク処理を実行し、出力ファイルを生成
+    match linker.link_to_file(output_path) {
+        Ok(_) => {
+            println!("リンク成功: {}", output_path.display());
+        },
+        Err(e) => {
+            eprintln!("リンクエラー: {}", e);
+            process::exit(1);
+        }
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,13 +6,24 @@ pub mod relocation;
 pub mod section;
 pub mod symbol;
 
-use crate::elf::Elf;
+use crate::elf::ELF;
 use crate::parser::error::ParseError;
 use nom::IResult;
 
+/// A type alias for the result of parsing operations, which includes the remaining input,
+/// the parsed value, and any potential parsing error.
 pub type ParseResult<'a, T> = IResult<&'a [u8], T, ParseError>;
 
-pub fn parse_elf(raw: &[u8]) -> ParseResult<Elf> {
+/// Parses the raw bytes of an ELF file into an `Elf` structure.
+///
+/// # Arguments
+///
+/// * `raw` - A byte slice containing the raw ELF file data.
+///
+/// # Returns
+///
+/// A `ParseResult` containing the parsed `Elf` structure or a `ParseError` if parsing fails.
+pub fn parse_elf(raw: &[u8]) -> ParseResult<ELF> {
     let header = header::parse(raw)?.1;
 
     let section_headers = section::parse_header(
@@ -29,7 +40,7 @@ pub fn parse_elf(raw: &[u8]) -> ParseResult<Elf> {
 
     Ok((
         &[],
-        Elf {
+        ELF {
             header,
             section_headers,
             symbols,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -14,7 +14,7 @@ use nom::IResult;
 /// the parsed value, and any potential parsing error.
 pub type ParseResult<'a, T> = IResult<&'a [u8], T, ParseError>;
 
-/// Parses the raw bytes of an ELF file into an `Elf` structure.
+/// Parses the raw bytes of an ELF file into an `ELF` structure.
 ///
 /// # Arguments
 ///
@@ -22,7 +22,7 @@ pub type ParseResult<'a, T> = IResult<&'a [u8], T, ParseError>;
 ///
 /// # Returns
 ///
-/// A `ParseResult` containing the parsed `Elf` structure or a `ParseError` if parsing fails.
+/// A `ParseResult` containing the parsed `ELF` structure or a `ParseError` if parsing fails.
 pub fn parse_elf(raw: &[u8]) -> ParseResult<ELF> {
     let header = header::parse(raw)?.1;
 

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -1,4 +1,4 @@
-trait ElfParseError {
+trait ELFParseError {
     fn as_parse_error(&self) -> ParseError;
 }
 
@@ -13,7 +13,7 @@ pub enum ParseError {
     InvalidMachine(u16),
     InvalidVersion(u32),
     InvalidHeaderSize(u8),
-    FileTypeNotElf([u8; 4]),
+    FileTypeNotELF([u8; 4]),
     // Section Header
     InvalidSectionType(u32),
     InvalidSectionFlags(u64),
@@ -26,7 +26,7 @@ pub enum ParseError {
     Nom(String),
 }
 
-impl ElfParseError for ParseError {
+impl ELFParseError for ParseError {
     fn as_parse_error(&self) -> ParseError {
         self.clone()
     }
@@ -43,7 +43,7 @@ impl<I: std::fmt::Debug> nom::error::ParseError<I> for ParseError {
 }
 
 // workaround
-impl<I, E: ElfParseError> nom::error::FromExternalError<I, E> for ParseError {
+impl<I, E: ELFParseError> nom::error::FromExternalError<I, E> for ParseError {
     fn from_external_error(_input: I, _kind: nom::error::ErrorKind, e: E) -> Self {
         e.as_parse_error()
     }

--- a/src/parser/header.rs
+++ b/src/parser/header.rs
@@ -119,19 +119,19 @@ impl TryFrom<u32> for Version {
 }
 
 fn parse_elf_class(raw: &[u8]) -> ParseResult<Class> {
-    map_res(le_u8, |b: u8| Class::try_from(b)).parse(raw)
+    map_res(le_u8, Class::try_from).parse(raw)
 }
 
 fn parse_elf_data(raw: &[u8]) -> ParseResult<Data> {
-    map_res(le_u8, |b: u8| Data::try_from(b)).parse(raw)
+    map_res(le_u8, Data::try_from).parse(raw)
 }
 
 fn parse_elf_ident_version(raw: &[u8]) -> ParseResult<IdentVersion> {
-    map_res(le_u8, |b: u8| IdentVersion::try_from(b)).parse(raw)
+    map_res(le_u8, IdentVersion::try_from).parse(raw)
 }
 
 fn parse_elf_osabi(raw: &[u8]) -> ParseResult<OSABI> {
-    map_res(le_u8, |b: u8| OSABI::try_from(b)).parse(raw)
+    map_res(le_u8, OSABI::try_from).parse(raw)
 }
 
 fn parse_ident(raw: &[u8]) -> ParseResult<Ident> {
@@ -155,15 +155,15 @@ fn parse_ident(raw: &[u8]) -> ParseResult<Ident> {
 }
 
 fn parse_type(raw: &[u8]) -> ParseResult<Type> {
-    map_res(le_u16, |b: u16| Type::try_from(b)).parse(raw)
+    map_res(le_u16, Type::try_from).parse(raw)
 }
 
 fn parse_machine(raw: &[u8]) -> ParseResult<Machine> {
-    map_res(le_u16, |b: u16| Machine::try_from(b)).parse(raw)
+    map_res(le_u16, Machine::try_from).parse(raw)
 }
 
 fn parse_version(raw: &[u8]) -> ParseResult<Version> {
-    map_res(le_u32, |b: u32| Version::try_from(b)).parse(raw)
+    map_res(le_u32, Version::try_from).parse(raw)
 }
 
 fn parse_magic_number(raw: &[u8]) -> IResult<&[u8], (), ParseError> {
@@ -172,12 +172,12 @@ fn parse_magic_number(raw: &[u8]) -> IResult<&[u8], (), ParseError> {
     }
     if raw[..4] != ELF_MAGIC_NUMBER {
         let input: [u8; 4] = raw[..4].try_into().unwrap();
-        bail_nom_error!(ParseError::FileTypeNotElf(input));
+        bail_nom_error!(ParseError::FileTypeNotELF(input));
     }
     Ok((&raw[4..], ()))
 }
 
-pub fn parse(raw: &[u8]) -> IResult<&[u8], Header, ParseError> {
+pub fn parse(raw: &[u8]) -> ParseResult<Header> {
     if raw.len() < ELF_IDENT_HEADER_SIZE {
         bail_nom_error!(ParseError::InvalidHeaderSize(raw.len() as u8));
     }
@@ -244,7 +244,7 @@ mod tests {
         let err = parse(input).unwrap_err();
         assert_eq!(
             err,
-            nom::Err::Error(ParseError::FileTypeNotElf([0, 0, 0, 0]))
+            nom::Err::Error(ParseError::FileTypeNotELF([0, 0, 0, 0]))
         );
     }
 

--- a/src/parser/helper.rs
+++ b/src/parser/helper.rs
@@ -1,18 +1,15 @@
-use super::ParseResult;
-
-pub fn get_string_by_offset(raw: &[u8], offset: usize) -> ParseResult<String> {
+pub fn get_string_by_offset(raw: &[u8], offset: usize) -> String {
     let mut end = offset;
     while raw[end] != 0 {
         end += 1;
     }
 
-    let name = String::from_utf8_lossy(&raw[offset..end]).to_string();
-    Ok((&[], name))
+    String::from_utf8_lossy(&raw[offset..end]).to_string()
 }
 
 #[test]
 fn get_string_by_offset_ok() {
     let bytes = b".text\0";
-    let (_, name) = get_string_by_offset(bytes, 0).unwrap();
+    let name = get_string_by_offset(bytes, 0);
     assert_eq!(name, ".text");
 }

--- a/src/parser/relocation.rs
+++ b/src/parser/relocation.rs
@@ -67,7 +67,7 @@ pub fn parse(section_headers: &[section::Header]) -> ParseResult<Vec<RelocationA
         },
         entry_count,
     )
-    .parse(header.data.as_ref())?;
+    .parse(header.section_raw_data.as_ref())?;
 
     Ok((rest, relocations))
 }

--- a/src/parser/relocation.rs
+++ b/src/parser/relocation.rs
@@ -41,7 +41,7 @@ fn parse_info(raw: &[u8]) -> ParseResult<Info> {
     map_res(le_u64, Info::try_from).parse(raw)
 }
 
-pub fn parse<'a>(section_headers: &'a [section::Header]) -> ParseResult<'a, Vec<RelocationAddend>> {
+pub fn parse(section_headers: &[section::Header]) -> ParseResult<Vec<RelocationAddend>> {
     let Some(header) = section_headers
         .iter()
         .find(|&s| s.r#type == section::SectionType::Rela)
@@ -67,7 +67,7 @@ pub fn parse<'a>(section_headers: &'a [section::Header]) -> ParseResult<'a, Vec<
         },
         entry_count,
     )
-    .parse(header.data)?;
+    .parse(header.data.as_ref())?;
 
     Ok((rest, relocations))
 }

--- a/src/parser/section.rs
+++ b/src/parser/section.rs
@@ -95,7 +95,7 @@ pub fn parse_header(
             let (rest, info) = le_u32(rest)?;
             let (rest, addralign) = le_u64(rest)?;
             let (rest, entsize) = le_u64(rest)?;
-            let data = &raw[offset as usize..(offset + size) as usize];
+            let data = raw[offset as usize..(offset + size) as usize].to_vec();
 
             let header = Header {
                 name_idx,

--- a/src/parser/section.rs
+++ b/src/parser/section.rs
@@ -73,6 +73,24 @@ fn parse_flags(raw: &[u8]) -> ParseResult<Vec<SectionFlag>> {
     .parse(raw)
 }
 
+/// Parses the section headers from the raw ELF file data.
+///
+/// # Arguments
+///
+/// * `raw` - A byte slice containing the raw ELF file data.
+/// * `shoff` - The offset in the file where the section header table begins.
+/// * `shstrndx` - The index of the section header string table in the section header table.
+/// * `shnum` - The number of section headers in the section header table.
+///
+/// # Returns
+///
+/// A `ParseResult` containing a vector of parsed `Header` structures or a `ParseError` if parsing fails.
+///
+/// # Notes
+///
+/// If `shnum` is 0, the function returns an empty vector of headers. The function uses a parser combinator
+/// to iterate through the section headers and extract their fields. After parsing, it resolves the section
+/// names using the section header string table.
 pub fn parse_header(
     raw: &[u8],
     shoff: usize,

--- a/src/parser/section.rs
+++ b/src/parser/section.rs
@@ -117,7 +117,7 @@ pub fn parse_header(
 
             let header = Header {
                 name_idx,
-                name: "".into(),
+                name: "".into(), // to be filled later
                 r#type,
                 flags,
                 addr,
@@ -127,7 +127,7 @@ pub fn parse_header(
                 info,
                 addralign,
                 entsize,
-                data,
+                section_raw_data: data,
             };
 
             Ok((rest, header))
@@ -135,12 +135,12 @@ pub fn parse_header(
         shnum,
     )
     .parse(&raw[shoff..])
-    .and_then(|(rest, mut headers)| {
+    .map(|(rest, mut headers)| {
         let string_table = &raw[headers[shstrndx].offset as usize..];
         for header in headers.iter_mut() {
-            header.name = helper::get_string_by_offset(string_table, header.name_idx as usize)?.1;
+            header.name = helper::get_string_by_offset(string_table, header.name_idx as usize);
         }
-        Ok((rest, headers))
+        (rest, headers)
     })
 }
 

--- a/src/parser/snapshots/yui__parser__section__tests__should_parse_section_header_table.snap
+++ b/src/parser/snapshots/yui__parser__section__tests__should_parse_section_header_table.snap
@@ -15,7 +15,7 @@ expression: header_table
         info: 0,
         addralign: 0,
         entsize: 0,
-        data: [],
+        section_raw_data: [],
     },
     Header {
         name_idx: 27,
@@ -32,7 +32,7 @@ expression: header_table
         info: 0,
         addralign: 1,
         entsize: 0,
-        data: [],
+        section_raw_data: [],
     },
     Header {
         name_idx: 33,
@@ -49,7 +49,7 @@ expression: header_table
         info: 0,
         addralign: 4,
         entsize: 0,
-        data: [
+        section_raw_data: [
             23,
             0,
             0,
@@ -71,7 +71,7 @@ expression: header_table
         info: 0,
         addralign: 1,
         entsize: 0,
-        data: [],
+        section_raw_data: [],
     },
     Header {
         name_idx: 44,
@@ -88,7 +88,7 @@ expression: header_table
         info: 0,
         addralign: 1,
         entsize: 1,
-        data: [
+        section_raw_data: [
             0,
             71,
             67,
@@ -143,7 +143,7 @@ expression: header_table
         info: 0,
         addralign: 1,
         entsize: 0,
-        data: [],
+        section_raw_data: [],
     },
     Header {
         name_idx: 1,
@@ -157,7 +157,7 @@ expression: header_table
         info: 8,
         addralign: 8,
         entsize: 24,
-        data: [
+        section_raw_data: [
             0,
             0,
             0,
@@ -388,7 +388,7 @@ expression: header_table
         info: 0,
         addralign: 1,
         entsize: 0,
-        data: [
+        section_raw_data: [
             0,
             115,
             117,
@@ -415,7 +415,7 @@ expression: header_table
         info: 0,
         addralign: 1,
         entsize: 0,
-        data: [
+        section_raw_data: [
             0,
             46,
             115,

--- a/src/parser/symbol.rs
+++ b/src/parser/symbol.rs
@@ -106,7 +106,7 @@ pub fn parse<'a>(raw: &'a [u8], section_headers: &'a [Header]) -> ParseResult<'a
         },
         entry_count,
     )
-    .parse(symbol_header.data)?;
+    .parse(symbol_header.data.as_ref())?;
 
     Ok((rest, symbols))
 }

--- a/src/parser/symbol.rs
+++ b/src/parser/symbol.rs
@@ -42,7 +42,7 @@ impl TryFrom<u8> for Info {
         };
 
         // low 4 bites: Type
-        // 0b00000001
+        // 0b01000001
         // 0b00001111
         // ----------
         // 0b00000001
@@ -92,7 +92,7 @@ pub fn parse<'a>(raw: &'a [u8], section_headers: &'a [Header]) -> ParseResult<'a
             let (rest, value) = le_u64(rest)?;
             let (rest, size) = le_u64(rest)?;
 
-            let name = helper::get_string_by_offset(string_table, name_idx as usize)?.1;
+            let name = helper::get_string_by_offset(string_table, name_idx as usize);
             let symbol = Symbol {
                 name,
                 info,
@@ -106,7 +106,7 @@ pub fn parse<'a>(raw: &'a [u8], section_headers: &'a [Header]) -> ParseResult<'a
         },
         entry_count,
     )
-    .parse(symbol_header.data.as_ref())?;
+    .parse(symbol_header.section_raw_data.as_ref())?;
 
     Ok((rest, symbols))
 }


### PR DESCRIPTION
- Introduced `Linker` struct to handle ELF linking.
- Added support for parsing and resolving symbols.
- Implemented section layout and relocation handling.
- Added tests for linker functionality.
- Updated `main.rs` to use the linker for creating executables.
